### PR TITLE
Rename intervention/inject docs to source

### DIFF
--- a/docs/documentation/intervention/index.md
+++ b/docs/documentation/intervention/index.md
@@ -7,7 +7,7 @@ Core intervention system for tracing and modifying model internals.
 ## Submodules
 
 - [envoy](envoy.md) - Envoy proxy system for module access
-- [inject](inject.md) - Injection utilities
+- [source](source.md) - Source utilities
 - [batching](batching.md) - Batching support
 - [interleaver](interleaver.md) - Interleaving execution
 - [serialization](serialization.md) - Serialization utilities

--- a/docs/documentation/intervention/inject.md
+++ b/docs/documentation/intervention/inject.md
@@ -1,3 +1,0 @@
-# inject
-
-::: nnsight.intervention.inject

--- a/docs/documentation/intervention/source.md
+++ b/docs/documentation/intervention/source.md
@@ -1,0 +1,3 @@
+# source
+
+::: nnsight.intervention.source

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,7 +125,7 @@ nav:
     - intervention:
       - documentation/intervention/index.md
       - envoy: documentation/intervention/envoy.md
-      - inject: documentation/intervention/inject.md
+      - source: documentation/intervention/source.md
       - batching: documentation/intervention/batching.md
       - interleaver: documentation/intervention/interleaver.md
       - serialization: documentation/intervention/serialization.md


### PR DESCRIPTION
## Summary
- The `nnsight.intervention.inject` module was renamed to `nnsight.intervention.source`; this updates the docs page, nav entry, and submodule index to match so `mkdocs build` succeeds against current nnsight.

## Test plan
- [x] `mkdocs serve` builds without `Could not collect 'nnsight.intervention.inject'` error
- [x] `/documentation/intervention/source/` page renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)